### PR TITLE
update registered type for identity with bip44

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,7 @@ uint32_t set_result_get_publicKey(void);
 
 #define HASH_TYPE_SHA512 1
 
-#define FACTOM_ID_TYPE 0x88888888
+#define FACTOM_ID_TYPE 0x80000119
 #define FCT_TYPE       0x80000083 
 #define EC_TYPE        0x80000084
 


### PR DESCRIPTION
the slip 44 registration team rejected our choice of using hex 8s as the bip44 coin type for identity.  They have agreed to use 281 as the factom identity coin type for regenerating identities later.  I will be updating the factom-walletd code with the new bip44 coin type before releasing it.

I have not tested this update.

https://github.com/satoshilabs/slips/pull/558

I hope this isn't too late for the ledger review.